### PR TITLE
テリトリーのハンズオン（地域別×業界別の組み合わせモデル）

### DIFF
--- a/force-app/main/default/settings/Territory2.settings-meta.xml
+++ b/force-app/main/default/settings/Territory2.settings-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Settings xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <defaultAccountAccessLevel>Edit</defaultAccountAccessLevel>
+    <defaultCaseAccessLevel>Edit</defaultCaseAccessLevel>
+    <defaultContactAccessLevel>Edit</defaultContactAccessLevel>
+    <defaultOpportunityAccessLevel>Edit</defaultOpportunityAccessLevel>
+    <enableTerritoryManagement2>true</enableTerritoryManagement2>
+    <opportunityFilterSettings>
+        <apexClassName xsi:nil="true"/>
+        <enableFilter>false</enableFilter>
+        <runMultiThreaded>false</runMultiThreaded>
+        <runOnCreate>false</runOnCreate>
+    </opportunityFilterSettings>
+    <showTM2EnabledBanner>false</showTM2EnabledBanner>
+    <t2ForecastAccessLevel>Read</t2ForecastAccessLevel>
+    <tm2BypassRealignAccInsert>false</tm2BypassRealignAccInsert>
+    <tm2EnableUserAssignmentLog>true</tm2EnableUserAssignmentLog>
+</Territory2Settings>

--- a/force-app/main/default/territory2Models/FY2025_Territory/FY2025_Territory.territory2Model-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/FY2025_Territory.territory2Model-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Model xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>FY2025テリトリーの地域・業界別営業担当管理</description>
+    <name>FY2025テリトリー</name>
+</Territory2Model>

--- a/force-app/main/default/territory2Models/FY2025_Territory/rules/EastJapanFinalcialRule.territory2Rule-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/rules/EastJapanFinalcialRule.territory2Rule-meta.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Rule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>true</active>
+    <booleanFilter>(1 OR 2 OR 3 OR 4) AND 5</booleanFilter>
+    <name>東日本金融業ルール</name>
+    <objectType>Account</objectType>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>東京</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>埼玉</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>神奈川</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>千葉</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.Industry</field>
+        <operation>contains</operation>
+        <value>Banking,Finance,Insurance</value>
+    </ruleItems>
+</Territory2Rule>

--- a/force-app/main/default/territory2Models/FY2025_Territory/rules/EastJapanITServiceRule.territory2Rule-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/rules/EastJapanITServiceRule.territory2Rule-meta.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Rule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>true</active>
+    <booleanFilter>(1 OR 2 OR 3 OR 4) AND 5</booleanFilter>
+    <name>東日本ITサービスルール</name>
+    <objectType>Account</objectType>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>東京</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>埼玉</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>神奈川</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>千葉</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.Industry</field>
+        <operation>contains</operation>
+        <value>Telecommunications,Engineering,Technology</value>
+    </ruleItems>
+</Territory2Rule>

--- a/force-app/main/default/territory2Models/FY2025_Territory/rules/EastJapanManufacturingRule.territory2Rule-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/rules/EastJapanManufacturingRule.territory2Rule-meta.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Rule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>true</active>
+    <booleanFilter>(1 OR 2 OR 3 OR 4) AND 5</booleanFilter>
+    <name>東日本製造業ルール</name>
+    <objectType>Account</objectType>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>東京</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>埼玉</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>神奈川</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>千葉</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.Industry</field>
+        <operation>contains</operation>
+        <value>Manufacturing,Engineering,Machinery,Electronics</value>
+    </ruleItems>
+</Territory2Rule>

--- a/force-app/main/default/territory2Models/FY2025_Territory/rules/WestJapanFinalcialRule.territory2Rule-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/rules/WestJapanFinalcialRule.territory2Rule-meta.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Rule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>true</active>
+    <booleanFilter>(1 OR 2 OR 3 OR 4 OR 5 OR 6) AND 7</booleanFilter>
+    <name>西日本金融業ルール</name>
+    <objectType>Account</objectType>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>大阪</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>京都</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>滋賀</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>奈良</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>和歌山</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>兵庫</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.Industry</field>
+        <operation>contains</operation>
+        <value>Banking,Finance,Insurance</value>
+    </ruleItems>
+</Territory2Rule>

--- a/force-app/main/default/territory2Models/FY2025_Territory/rules/WestJapanITServiceRule.territory2Rule-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/rules/WestJapanITServiceRule.territory2Rule-meta.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Rule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>true</active>
+    <booleanFilter>(1 OR 2 OR 3 OR 4 OR 5 OR 6) AND 7</booleanFilter>
+    <name>西日本ITサービスルール</name>
+    <objectType>Account</objectType>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>大阪</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>京都</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>滋賀</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>奈良</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>和歌山</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>兵庫</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.Industry</field>
+        <operation>contains</operation>
+        <value>Telecommunications,Engineering,Technology</value>
+    </ruleItems>
+</Territory2Rule>

--- a/force-app/main/default/territory2Models/FY2025_Territory/rules/WestJapanManufacturingRule.territory2Rule-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/rules/WestJapanManufacturingRule.territory2Rule-meta.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Rule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>true</active>
+    <booleanFilter>(1 OR 2 OR 3 OR 4 OR 5 OR 6) AND 7</booleanFilter>
+    <name>西日本製造業ルール</name>
+    <objectType>Account</objectType>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>大阪</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>京都</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>滋賀</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>奈良</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>和歌山</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.BillingState</field>
+        <operation>equals</operation>
+        <value>兵庫</value>
+    </ruleItems>
+    <ruleItems>
+        <field>Account.Industry</field>
+        <operation>contains</operation>
+        <value>Manufacturing,Engineering,Machinery,Electronics</value>
+    </ruleItems>
+</Territory2Rule>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/CampanyAll.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/CampanyAll.territory2-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Read</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>全社用</description>
+    <name>全社</name>
+    <opportunityAccessLevel>Read</opportunityAccessLevel>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapan.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapan.territory2-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>東日本</description>
+    <name>東日本</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>CampanyAll</parentTerritory>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapanFinalcialIndustory.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapanFinalcialIndustory.territory2-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>東日本の金融業</description>
+    <name>金融業</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>EastJapan</parentTerritory>
+    <ruleAssociations>
+        <inherited>false</inherited>
+        <ruleName>EastJapanFinalcialRule</ruleName>
+    </ruleAssociations>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapanITServiceIndustory.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapanITServiceIndustory.territory2-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>東日本のIT・サービス業</description>
+    <name>IT・サービス業</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>EastJapan</parentTerritory>
+    <ruleAssociations>
+        <inherited>false</inherited>
+        <ruleName>EastJapanITServiceRule</ruleName>
+    </ruleAssociations>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapanManufacturingIndustory.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/EastJapanManufacturingIndustory.territory2-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>東日本の製造業</description>
+    <name>製造業</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>EastJapan</parentTerritory>
+    <ruleAssociations>
+        <inherited>false</inherited>
+        <ruleName>EastJapanManufacturingRule</ruleName>
+    </ruleAssociations>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapan.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapan.territory2-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <name>西日本</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>CampanyAll</parentTerritory>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapanFinalcialIndustory.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapanFinalcialIndustory.territory2-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>西日本の金融業</description>
+    <name>金融業</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>WestJapan</parentTerritory>
+    <ruleAssociations>
+        <inherited>false</inherited>
+        <ruleName>WestJapanFinalcialRule</ruleName>
+    </ruleAssociations>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapanITServiceIndustory.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapanITServiceIndustory.territory2-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>西日本のIT・サービス業</description>
+    <name>IT・サービス業</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>WestJapan</parentTerritory>
+    <ruleAssociations>
+        <inherited>true</inherited>
+        <ruleName>WestJapanITServiceRule</ruleName>
+    </ruleAssociations>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapanManufacturingIndustory.territory2-meta.xml
+++ b/force-app/main/default/territory2Models/FY2025_Territory/territories/WestJapanManufacturingIndustory.territory2-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2 xmlns="http://soap.sforce.com/2006/04/metadata">
+    <accountAccessLevel>Edit</accountAccessLevel>
+    <caseAccessLevel>Edit</caseAccessLevel>
+    <contactAccessLevel>Edit</contactAccessLevel>
+    <description>西日本の製造業</description>
+    <name>製造業</name>
+    <opportunityAccessLevel>Edit</opportunityAccessLevel>
+    <parentTerritory>WestJapan</parentTerritory>
+    <ruleAssociations>
+        <inherited>false</inherited>
+        <ruleName>WestJapanManufacturingRule</ruleName>
+    </ruleAssociations>
+    <territory2Type>Regional_Industry_Territory</territory2Type>
+</Territory2>

--- a/force-app/main/default/territory2Types/Regional_Industry_Territory.territory2Type-meta.xml
+++ b/force-app/main/default/territory2Types/Regional_Industry_Territory.territory2Type-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Territory2Type xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>地域と業界による営業テリトリー管理</description>
+    <name>地域・業界別テリトリー</name>
+    <priority>1</priority>
+</Territory2Type>


### PR DESCRIPTION
## やったこと

#31

テリトリーの概念と作り方がよくわからなかったため、Claudeにサンプル設計してもらい、生成してもらった手順にしたがってテリトリーを作成してみた。

<details><summary>作成手順</summary>
<p>

# Salesforceテリトリー管理設定手順

## 主な機能

- 営業担当者の担当エリア・業界の明確化
- 取引先・商談の自動割り当て
- 階層構造での管理（本部→支社→営業所など）
- アクセス権限の自動設定
- 売上実績の集計・分析

## よくあるテリトリーモデル例

地域別×業界別の組み合わせモデル：

```
全社
├── 東日本
│   ├── 製造業
│   ├── 金融業
│   └── IT・サービス業
└── 西日本
    ├── 製造業
    ├── 金融業
    └── IT・サービス業
```

## 設定手順

### 1. テリトリー管理の有効化

1. 設定 → 会社設定 → テリトリー設定
2. 「テリトリー管理を有効化」をチェック  
3. 保存

### 2. テリトリータイプの作成

1. 設定 → テリトリー管理 → テリトリータイプ
2. 「新規」をクリック
3. 以下を設定：
   - 表示ラベル：「地域・業界別テリトリー」
   - API参照名：「Regional_Industry_Territory」
   - 説明：「地域と業界による営業テリトリー管理」
4. 保存

### 3. テリトリーモデルの作成

1. 設定 → テリトリー管理 → テリトリーモデル
2. 「新規テリトリーモデル」をクリック
3. 設定内容：
   - テリトリーモデル名：「2024年度営業テリトリー」
   - 説明：「地域・業界別営業担当管理」
   - 状態：「計画中」

### 4. テリトリーの作成

1. 作成したモデルを開く
2. 「テリトリーを追加」で階層を作成：

**レベル1（全社）**
- テリトリー名：「全社」
- テリトリータイプ：「地域・業界別テリトリー」

**レベル2（地域）**
- 「東日本」「西日本」を全社の下に作成

**レベル3（業界）**
- 各地域の下に「製造業」「金融業」「IT・サービス業」を作成

### 5. 割り当てルールの設定

各最下位テリトリーに対して：

1. テリトリーを選択 → 「割り当てルール」タブ
2. 「新規ルール」をクリック
3. 条件設定例（東日本・製造業の場合）：
   - 取引先.都道府県 = 東京都,神奈川県,埼玉県,千葉県,茨城県...
   - かつ 取引先.業界 = 製造業

### 6. ユーザーの割り当て

1. 各テリトリーの「ユーザー」タブ
2. 「ユーザーを割り当て」をクリック
3. 担当営業を選択してロールを設定

### 7. モデルの有効化

1. テリトリーモデル画面で「有効化」をクリック
2. 既存データの再割り当て実行

## 完了

これで設定完了！取引先が自動的に適切なテリトリーに割り当てられ、営業担当者のアクセス権限も自動設定される。


</p>
</details> 